### PR TITLE
[issue #3] Now spawning a specific number of players specified in the config.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ debug=false
 
 [dependencies]
 bevy = "0.13.0"
+rand = "0.8.5"

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -1,32 +1,135 @@
 use bevy::prelude::*;
+use bevy::sprite::MaterialMesh2dBundle;
+use bevy::sprite::Mesh2dHandle;
+use std::collections::HashMap;
 
 use crate::engine::config::*;
+use crate::simulation::players::Player;
 
-fn grid_to_world(grid_pos: u32) -> f32 {
-    grid_pos as f32 * (DEFAULT_TILE_SIZE + default_tile_margin()) - DEFAULT_GRID_SIZE as f32 * (DEFAULT_TILE_SIZE + default_tile_margin()) / 2.0 + DEFAULT_TILE_SIZE / 2.0
+use super::random::random_board_pos;
+
+#[derive(Component, Debug, PartialEq, Eq, Hash)]
+pub struct BoardPosition {
+    x: u32,
+    y: u32,
 }
 
-fn spawn_board(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+#[derive(Component, Debug)]
+pub enum OccupantType {
+    Empty,
+    Player(Entity),
+}
+
+#[derive(Component, Debug)]
+pub struct BoardTile;
+
+impl BoardPosition {
+    pub fn new(x: u32, y: u32) -> Self {
+        Self { x, y }
+    }
+
+    pub fn from_tuple((x, y): (u32, u32)) -> Self {
+        Self { x, y }
+    }
+}
+
+#[derive(Bundle)]
+pub struct BoardTileBundle {
+    pub pos: BoardPosition,
+    pub occupant: OccupantType,
+    pub sprite: SpriteBundle,
+}
+
+#[derive(Resource)]
+struct BoardState {
+    tiles: HashMap<BoardPosition, Entity>,
+}
+
+impl BoardState {
+    pub fn new() -> Self {
+        Self {
+            tiles: HashMap::new(),
+        }
+    }
+}
+
+fn grid_to_world(grid_pos: u32) -> f32 {
+    grid_pos as f32 * (DEFAULT_TILE_SIZE + default_tile_margin())
+        - DEFAULT_GRID_SIZE as f32 * (DEFAULT_TILE_SIZE + default_tile_margin()) / 2.0
+        + DEFAULT_TILE_SIZE / 2.0
+}
+
+fn spawn_board(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut board_state: ResMut<BoardState>,
+) {
     let tile_color = Color::rgb(0.5, 0.5, 0.5);
     materials.add(tile_color);
 
     for x in 0..DEFAULT_GRID_SIZE {
         for y in 0..DEFAULT_GRID_SIZE {
-            commands.spawn(
-                SpriteBundle {
-                    sprite: Sprite {
-                        color: tile_color.clone(),
-                        custom_size: Some(Vec2::new(DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)),
-                        ..default()
+            let tile_entity = commands
+                .spawn((
+                    BoardTileBundle {
+                        pos: BoardPosition::new(x, y),
+                        occupant: OccupantType::Empty,
+                        sprite: SpriteBundle {
+                            sprite: Sprite {
+                                color: tile_color,
+                                custom_size: Some(Vec2::new(DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE)),
+                                ..default()
+                            },
+                            transform: Transform::from_xyz(grid_to_world(x), grid_to_world(y), 0.0),
+                            ..Default::default()
+                        },
                     },
-                    transform: Transform::from_xyz(
-                        grid_to_world(x),
-                        grid_to_world(y),
-                        0.0,
-                    ),
-                    ..Default::default()
-                }
-            );
+                    BoardTile,
+                ))
+                .id();
+            board_state
+                .tiles
+                .insert(BoardPosition::new(x, y), tile_entity);
+        }
+    }
+}
+
+fn spawn_players(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    board_state: Res<BoardState>,
+    mut query: Query<&mut OccupantType, With<BoardTile>>,
+) {
+    for _ in 0..default_player_count() {
+        loop {
+            let random_pos = BoardPosition::from_tuple(random_board_pos());
+            let tile_entity = *board_state.tiles.get(&random_pos).unwrap();
+            if let Ok(mut occupant) = query.get_mut(tile_entity) {
+                let triangle = Mesh2dHandle(meshes.add(Triangle2d::new(
+                    Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
+                    Vec2::new(default_entity_size() / 2., 0.),
+                    Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
+                )));
+                *occupant = OccupantType::Player(
+                    commands
+                        .spawn((
+                            MaterialMesh2dBundle {
+                                mesh: triangle,
+                                material: materials.add(Color::rgb(1.0, 0.0, 0.0)),
+                                transform: Transform::from_xyz(
+                                    grid_to_world(random_pos.x),
+                                    grid_to_world(random_pos.y),
+                                    0.1,
+                                ),
+                                ..default()
+                            },
+                            Player,
+                        ))
+                        .id(),
+                );
+                break;
+            }
         }
     }
 }
@@ -35,6 +138,7 @@ pub struct GameBoardPlugin;
 
 impl Plugin for GameBoardPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_board);
+        app.insert_resource(BoardState::new())
+            .add_systems(Startup, (spawn_board, spawn_players).chain());
     }
 }

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -3,13 +3,16 @@ pub fn percent(value: u8) -> f32 {
 }
 
 pub const DEFAULT_GRID_SIZE: u32 = 16;
-pub const DEFAULT_TILE_SIZE: f32 = 35.0;
-// pub fn default_entity_to_tile_ratio() -> f32 {
-//     percent(80)
-// }
-// pub fn default_entity_size() -> f32 {
-//     DEFAULT_TILE_SIZE * default_entity_to_tile_ratio()
-// }
+pub const DEFAULT_TILE_SIZE: f32 = 38.0;
+pub fn default_entity_to_tile_ratio() -> f32 {
+    percent(80)
+}
+pub fn default_entity_size() -> f32 {
+    DEFAULT_TILE_SIZE * default_entity_to_tile_ratio()
+}
 pub fn default_tile_margin() -> f32 {
     DEFAULT_TILE_SIZE * percent(15)
+}
+pub fn default_player_count() -> u32 {
+    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
 pub mod board;
 pub mod config;
+pub mod random;
 pub mod rsystem;

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -1,0 +1,12 @@
+use rand::{thread_rng, Rng};
+
+use crate::engine::config::*;
+
+pub fn random_board_pos() -> (u32, u32) {
+    let mut rng = thread_rng();
+
+    (
+        rng.gen_range(0..DEFAULT_GRID_SIZE),
+        rng.gen_range(0..DEFAULT_GRID_SIZE),
+    )
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod engine;
+mod simulation;
 
 use bevy::prelude::*;
 

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -1,0 +1,1 @@
+pub mod players;

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -1,0 +1,4 @@
+use bevy::prelude::*;
+
+#[derive(Component, Debug)]
+pub struct Player;


### PR DESCRIPTION
The players are held as entities within board tiles. The specific configurations of components a player consists of as well as player capacities like movement and fighting are to be determined later. This is just to spawn players as entities within Bevy as well as on the screen.