### PR TITLE
[#6] Concept of player action along with moving and turning implemented, length of generation introduced, plus refactoring/cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ Runger is a hunger games style simulation game (?) written in Rust (hence the na
 
 ## The point and the concept
 
-The main point of this project is to experiment with / research the concept of [genetic programming](https://en.wikipedia.org/wiki/Genetic_programming) and simulation of generations of in-game "players". The players usually start with close to nothing, and their main objective is to survive: they have to kill other "players" and compete for resources (such as food). The drive to act may be hunger. The point of the simulation is to find the player with the perfect set of genes. Players operate in generations (one generation lasts until everyone is dead). After a generation, the most "successful" players get chosen for production of the next generation, which may involve crossing them with each other ("breeding") and an injection of random genes (mutations). After that, the next generation starts. And ideally this should last until the "perfect specimens" are found, that is, ones that never die.
+The main point of this project is to experiment with / research the concept of [genetic programming](https://en.wikipedia.org/wiki/Genetic_programming) and simulation of generations of in-game "players". The players usually start with close to nothing, and their main objective is to survive: they have to kill other players and compete for resources (such as food). The drive to act may be hunger. The point of the simulation is to find the player with the perfect set of genes. Players operate in generations (one generation lasts for a certain number of turns). After a generation, the most "successful" players get chosen for production of the next generation, which may involve crossing them with each other ("breeding") and an injection of random genes (mutations). After that, the next generation starts. And ideally this should last until the "perfect specimens" are found, that is, ones that never die.
 
 ## Experimental nature of the project
 
-This project is ridiculously experimental. It's intended to be developed and maintained for a relatively long time (at least several months, potentially more if it goes well), but it's being built with Rust + Amethyst. While Rust itself is a relatively mature language (with a very young infrastructure though), Amethyst is a very new crate/game engine and it's not in any way feature-complete or even stable yet. This project is intended to experiment with new technology just as much as with the genetic programming concept. I have no clue where this will end up in a few months from now (today, at the time of writing this, is 03/21/2021), so we'll see.
+This project is ridiculously experimental. It's intended to be developed and maintained for a relatively long time (at least several months, potentially more if it goes well), but it's being built with Rust + Bevy. While Rust itself is a relatively mature language (with a very young infrastructure though), Bevy is a new crate/game engine and is changing rapidly with each version. This project is intended to experiment with new technology just as much as with the genetic programming concept. 
+
+Once the "hunger games" simulation is finished, I may start adding other types of simulation just to see if the players can adjust to radically different conditions of their worlds. Therefore, this project potentially doesn't have an end date. Once I figure out where to move next, I'll update this README. For now, I'm focused on the Hunger Games implementation.
 
 ## Future plans
 
-The project has just started. Even though it's intended to be developed/maintained for quite a while, I'm a single dev who's working on this thing, and my knowledge of Rust /genetic programming / 2D graphics / game dev is also extremely limited. This is also a secondary project of mine (working on it for approximately 2 days a week). Therefore, the progress is going to happen, but it's going to most likely be slow.
+The project has just started. Even though it's intended to be developed/maintained for quite a while, I'm a single dev and due to the above-mentioned experimental nature of the project, just about everything is an experiment with this project.
 
-The plans for now are to release the 0.1.0 version. The plans for that are modest: for 0.1.0, I just want to have the board with players/agents, and they should be taking a single turn (making their move once) when you press space. Maybe they'll also going to have the ability to attack other players and try to find food. That is pretty much it. All the generations production / breeding / finding the fittest specimens is going to come in later versions, this is just for the very basics.
+The plans for now are to release the 0.1.0 version. The plans for that are modest: for 0.1.0, we'll have some number of players on the board, they kill, roam around looking for food, and try to survive. At the end of the generation, they're crossed with the other surviving players, the new gen is produced and those guys start playing instead. We'll also be able to simulate a number of generations and only enable visualization/graphics to show the nth generation (once they've evolved and got a bit smarter than the first random ones were), therefore showcasing the genetic evolution. That's it for the first release. 
 
 To know what's going on with Runger currently and where it is moving, please look at the [milestones](https://github.com/Oleksii-Kshenskyi/runger/milestones) page. The most recent milestone is usually the one being worked on.
-- 0.1.0 is for the basic graphics/board development/players and resources development.
-- 0.2.0 is for the genetics part of the application.
-- 0.3.0 is maybe going to introduce some ability for the human player/observer/user to influence the simulation in some way. Also, refining the genetic algorithm and introducing new systems (maybe new resources, or evolving new abilities for the players) is planned for around this version.
-- 0.4.0 and beyond are going to focus on refining the existing systems in the simulation and potentially introducing new interesting features.
+- 0.1.0 is for the basic graphics/board development/players and resources development, as well as the basics of genetics/evolution and non-graphical simulation of several generations.
+- Future versions are going to focus on improving the existing simulation, adding features and potentially developing different kinds of simulations and win conditions, other than just hunger games and "try not to die".
 
 ## Building and running
 
@@ -30,3 +30,5 @@ When/if any new build conditions are introduced, they will be reflected here in 
 ## Licensing
 
 Runger is licensed under [The Unlicense](https://unlicense.org/). This means that Runger is public domain and anyone can do whatever the heck they want with it. And no, you don't owe me to redistribute any copyright notices or anything. Public domain means this software effectively doesn't belong to me, so no copyrights are possible. It's yours to do whatever you want with it, without any obligations (not even the minimal ones), and that's it.
+
+However, in the future the licensing on this may change. If the project gets off the ground and becomes a fairly complex simulation of evolution, I may end up picking an opensource-only license like GPLv2 to encourage contribution and open nature of the project.

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -94,6 +94,12 @@ fn spawn_board(
     }
 }
 
+// TODO: The player bundle should feature:
+//  -- The direction the player is facing;
+
+//  TODO: there should be an update system that advances the board by 1 turn;
+// -- This could include stuff like players choosing which actions to take,
+// -- players moving, turning, etc.
 fn spawn_players(
     mut commands: Commands,
     mut materials: ResMut<Assets<ColorMaterial>>,

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -116,9 +116,6 @@ fn spawn_board(
     }
 }
 
-//  TODO: there should be an update system that advances the board by 1 turn;
-// -- This could include stuff like players choosing which actions to take,
-// -- players moving, turning, etc.
 fn spawn_players(
     mut commands: Commands,
     mut materials: ResMut<Assets<ColorMaterial>>,
@@ -163,6 +160,8 @@ fn spawn_players(
     }
 }
 
+// TODO: Try to refactor turning a player into just using rotation on the transform
+//       instead of recreating the mesh all the time.
 fn turn_player(
     direction: &mut FacingDirection,
     mesh: &mut Mesh2dHandle,
@@ -173,6 +172,9 @@ fn turn_player(
     *mesh = triangle_facing(direction, meshes);
 }
 
+// TODO: Think how to collapse this monster into a more pleasant looking function.
+//       Maybe extract a few of these phases into separate functions
+// TODO: In general, reflect whether it's possible to further refactor this code
 fn move_player(
     is_facing: &FacingDirection,
     tile_query: &mut Query<&mut OccupantType, With<BoardTile>>,

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -175,7 +175,7 @@ fn turn_player(
 
 fn move_player(
     is_facing: &FacingDirection,
-    tile_query: &mut Query<(&mut OccupantType, &BoardPosition), With<BoardTile>>,
+    tile_query: &mut Query<&mut OccupantType, With<BoardTile>>,
     player_pos: &mut BoardPosition,
     player_transform: &mut Transform,
     board_state: &Res<BoardState>,
@@ -199,11 +199,10 @@ fn move_player(
     };
     let allowed_to_move = within_bounds
         && maybe_new_entity.is_some()
-        && *tile_query
+        && **tile_query
             .get(*maybe_new_entity.unwrap())
             .as_ref()
             .unwrap()
-            .0
             == OccupantType::Empty; // if new (destination) tile's occupant type is empty
     if !allowed_to_move {
         return;
@@ -212,13 +211,13 @@ fn move_player(
     let new_tile_id = *maybe_new_entity.unwrap();
     let old_tile_id = *board_state.tiles.get(player_pos).unwrap();
     // extract old tile's old occupant type (Player(Entity))
-    let old_tile_occ = { *tile_query.get_mut(old_tile_id).unwrap().0 };
+    let old_tile_occ = { *tile_query.get_mut(old_tile_id).unwrap() };
     // new tile occ = Player(Entity)
-    if let Ok((mut new_tile_occ, _)) = tile_query.get_mut(new_tile_id) {
+    if let Ok(mut new_tile_occ) = tile_query.get_mut(new_tile_id) {
         *new_tile_occ = old_tile_occ;
     }
     // old tile occ = empty
-    if let Ok((mut old_tile_occ, _)) = tile_query.get_mut(old_tile_id) {
+    if let Ok(mut old_tile_occ) = tile_query.get_mut(old_tile_id) {
         *old_tile_occ = OccupantType::Empty;
     }
     // redraw player (transform)
@@ -242,7 +241,7 @@ fn advance_players(
     mut meshes: ResMut<Assets<Mesh>>,
     mut turn: ResMut<Turn>,
     board_state: Res<BoardState>,
-    mut tile_query: Query<(&mut OccupantType, &BoardPosition), With<BoardTile>>,
+    mut tile_query: Query<&mut OccupantType, With<BoardTile>>,
     mut player_query: Query<
         (
             &mut BoardPosition,

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -1,26 +1,30 @@
 use bevy::prelude::*;
-use bevy::sprite::MaterialMesh2dBundle;
-use bevy::sprite::Mesh2dHandle;
+use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
 use std::collections::HashMap;
 
 use crate::engine::config::*;
+use crate::simulation::players::position_after_turn;
+use crate::simulation::players::FacingDirection;
 use crate::simulation::players::Player;
+use crate::simulation::players::PlayerActionType;
 
+use super::common::triangle_facing;
 use super::random::random_board_pos;
+use super::random::random_player_action;
 
-#[derive(Component, Debug, PartialEq, Eq, Hash)]
+#[derive(Component, Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub struct BoardPosition {
     x: u32,
     y: u32,
 }
 
-#[derive(Component, Debug)]
+#[derive(Component, Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum OccupantType {
     Empty,
     Player(Entity),
 }
 
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Copy, Clone)]
 pub struct BoardTile;
 
 impl BoardPosition {
@@ -40,9 +44,27 @@ pub struct BoardTileBundle {
     pub sprite: SpriteBundle,
 }
 
+#[derive(Bundle)]
+pub struct PlayerBundle {
+    pub board_pos: BoardPosition,
+    pub is_facing: FacingDirection,
+    pub sprite: MaterialMesh2dBundle<ColorMaterial>,
+}
+
 #[derive(Resource)]
 struct BoardState {
     tiles: HashMap<BoardPosition, Entity>,
+}
+
+#[derive(Resource)]
+struct Turn {
+    num: u32,
+}
+
+impl Turn {
+    pub fn new() -> Self {
+        Self { num: 1 }
+    }
 }
 
 impl BoardState {
@@ -94,9 +116,6 @@ fn spawn_board(
     }
 }
 
-// TODO: The player bundle should feature:
-//  -- The direction the player is facing;
-
 //  TODO: there should be an update system that advances the board by 1 turn;
 // -- This could include stuff like players choosing which actions to take,
 // -- players moving, turning, etc.
@@ -120,15 +139,19 @@ fn spawn_players(
                 *occupant = OccupantType::Player(
                     commands
                         .spawn((
-                            MaterialMesh2dBundle {
-                                mesh: triangle,
-                                material: materials.add(Color::rgb(1.0, 0.0, 0.0)),
-                                transform: Transform::from_xyz(
-                                    grid_to_world(random_pos.x),
-                                    grid_to_world(random_pos.y),
-                                    0.1,
-                                ),
-                                ..default()
+                            PlayerBundle {
+                                board_pos: random_pos,
+                                is_facing: FacingDirection::Right,
+                                sprite: MaterialMesh2dBundle {
+                                    mesh: triangle,
+                                    material: materials.add(Color::rgb(1.0, 0.0, 0.0)),
+                                    transform: Transform::from_xyz(
+                                        grid_to_world(random_pos.x),
+                                        grid_to_world(random_pos.y),
+                                        0.1,
+                                    ),
+                                    ..default()
+                                },
                             },
                             Player,
                         ))
@@ -140,11 +163,136 @@ fn spawn_players(
     }
 }
 
+fn turn_player(
+    direction: &mut FacingDirection,
+    mesh: &mut Mesh2dHandle,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    turn_direction: FacingDirection,
+) {
+    *direction = position_after_turn(direction, turn_direction).unwrap();
+    *mesh = triangle_facing(direction, meshes);
+}
+
+fn move_player(
+    is_facing: &FacingDirection,
+    tile_query: &mut Query<(&mut OccupantType, &BoardPosition), With<BoardTile>>,
+    player_pos: &mut BoardPosition,
+    player_transform: &mut Transform,
+    board_state: &Res<BoardState>,
+) {
+    let new_pos: (i32, i32) = match (&player_pos, is_facing) {
+        (BoardPosition { x, y }, FacingDirection::Up) => (*x as i32, (*y + 1) as i32),
+        (BoardPosition { x, y }, FacingDirection::Right) => ((*x + 1) as i32, *y as i32),
+        (BoardPosition { x, y }, FacingDirection::Down) => (*x as i32, (*y - 1) as i32),
+        (BoardPosition { x, y }, FacingDirection::Left) => ((*x - 1) as i32, *y as i32),
+    };
+    let within_bounds = new_pos.0 >= 0
+        && new_pos.1 >= 0
+        && new_pos.0 < DEFAULT_GRID_SIZE as i32
+        && new_pos.1 < DEFAULT_GRID_SIZE as i32;
+    let maybe_new_entity = if within_bounds {
+        board_state
+            .tiles
+            .get(&BoardPosition::new(new_pos.0 as u32, new_pos.1 as u32))
+    } else {
+        None
+    };
+    let allowed_to_move = within_bounds
+        && maybe_new_entity.is_some()
+        && *tile_query
+            .get(*maybe_new_entity.unwrap())
+            .as_ref()
+            .unwrap()
+            .0
+            == OccupantType::Empty; // if new (destination) tile's occupant type is empty
+    if !allowed_to_move {
+        return;
+    }
+
+    let new_tile_id = *maybe_new_entity.unwrap();
+    let old_tile_id = *board_state.tiles.get(player_pos).unwrap();
+    // extract old tile's old occupant type (Player(Entity))
+    let old_tile_occ = { *tile_query.get_mut(old_tile_id).unwrap().0 };
+    // new tile occ = Player(Entity)
+    if let Ok((mut new_tile_occ, _)) = tile_query.get_mut(new_tile_id) {
+        *new_tile_occ = old_tile_occ;
+    }
+    // old tile occ = empty
+    if let Ok((mut old_tile_occ, _)) = tile_query.get_mut(old_tile_id) {
+        *old_tile_occ = OccupantType::Empty;
+    }
+    // redraw player (transform)
+    *player_transform = Transform::from_xyz(
+        grid_to_world(new_pos.0 as u32),
+        grid_to_world(new_pos.1 as u32),
+        0.1,
+    );
+    // update new player board position
+    *player_pos = BoardPosition {
+        x: new_pos.0 as u32,
+        y: new_pos.1 as u32,
+    };
+}
+
+fn simulation_ongoing(turn: Res<Turn>) -> bool {
+    turn.num <= TURNS_PER_GEN
+}
+
+fn advance_players(
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut turn: ResMut<Turn>,
+    board_state: Res<BoardState>,
+    mut tile_query: Query<(&mut OccupantType, &BoardPosition), With<BoardTile>>,
+    mut player_query: Query<
+        (
+            &mut BoardPosition,
+            &mut FacingDirection,
+            &mut Mesh2dHandle,
+            &mut Transform,
+        ),
+        With<Player>,
+    >,
+) {
+    for (mut pos, mut direction, mut mesh, mut transform) in player_query.iter_mut() {
+        match random_player_action() {
+            PlayerActionType::Idle => (),
+            PlayerActionType::Move => move_player(
+                &direction,
+                &mut tile_query,
+                &mut pos,
+                &mut transform,
+                &board_state,
+            ),
+            PlayerActionType::Turn(FacingDirection::Right) => turn_player(
+                &mut direction,
+                &mut mesh,
+                &mut meshes,
+                FacingDirection::Right,
+            ),
+            PlayerActionType::Turn(FacingDirection::Left) => turn_player(
+                &mut direction,
+                &mut mesh,
+                &mut meshes,
+                FacingDirection::Left,
+            ),
+            act => unreachable!(
+                "Incorrect action type while trying to advance players: {:#?}",
+                act
+            ),
+        }
+    }
+
+    turn.num += 1;
+}
+
 pub struct GameBoardPlugin;
 
 impl Plugin for GameBoardPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(BoardState::new())
-            .add_systems(Startup, (spawn_board, spawn_players).chain());
+            .insert_resource(Time::<Fixed>::from_seconds(SECONDS_PER_TURN))
+            .insert_resource(Turn::new())
+            .add_systems(Startup, (spawn_board, spawn_players).chain())
+            .add_systems(FixedUpdate, advance_players.run_if(simulation_ongoing));
     }
 }

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -1,7 +1,8 @@
-use std::{error::Error, fmt::Display};
+use std::{collections::HashMap, error::Error, fmt::Display};
 
 use bevy::{prelude::*, sprite::Mesh2dHandle};
 
+use crate::engine::config::*;
 use crate::simulation::players::FacingDirection;
 
 use super::config::default_entity_size;
@@ -51,4 +52,68 @@ pub fn triangle_facing(
             Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
         ))),
     }
+}
+
+#[derive(Component, Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub struct BoardPosition {
+    pub x: u32,
+    pub y: u32,
+}
+
+impl BoardPosition {
+    pub fn new(x: u32, y: u32) -> Self {
+        Self { x, y }
+    }
+
+    pub fn from_tuple((x, y): (u32, u32)) -> Self {
+        Self { x, y }
+    }
+}
+
+#[derive(Component, Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum OccupantType {
+    Empty,
+    Player(Entity),
+}
+
+#[derive(Resource)]
+pub struct BoardState {
+    pub tiles: HashMap<BoardPosition, Entity>,
+}
+
+#[derive(Component, Debug, Copy, Clone)]
+pub struct BoardTile;
+
+pub fn predict_move_pos(player_pos: &BoardPosition, is_facing: &FacingDirection) -> (i32, i32) {
+    match (&player_pos, is_facing) {
+        (BoardPosition { x, y }, FacingDirection::Up) => (*x as i32, (*y + 1) as i32),
+        (BoardPosition { x, y }, FacingDirection::Right) => ((*x + 1) as i32, *y as i32),
+        (BoardPosition { x, y }, FacingDirection::Down) => (*x as i32, (*y - 1) as i32),
+        (BoardPosition { x, y }, FacingDirection::Left) => ((*x - 1) as i32, *y as i32),
+    }
+}
+
+pub fn tile_entity_by_pos<'a>(
+    new_pos: (i32, i32),
+    board_state: &'a Res<BoardState>,
+) -> Option<&'a Entity> {
+    let within_bounds = new_pos.0 >= 0
+        && new_pos.1 >= 0
+        && new_pos.0 < DEFAULT_GRID_SIZE as i32
+        && new_pos.1 < DEFAULT_GRID_SIZE as i32;
+    if within_bounds {
+        board_state
+            .tiles
+            .get(&BoardPosition::new(new_pos.0 as u32, new_pos.1 as u32))
+    } else {
+        None
+    }
+}
+
+pub fn player_can_move_here(
+    tile_entity: &Entity,
+    tile_query: &mut Query<&mut OccupantType, With<BoardTile>>,
+) -> bool {
+    *tile_query.get(*tile_entity).unwrap() == OccupantType::Empty
+    // if new (destination) tile's occupant type is empty
 }

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -1,11 +1,9 @@
-use std::{collections::HashMap, error::Error, fmt::Display};
+use std::{collections::HashMap, error::Error, f32::consts::PI, fmt::Display};
 
-use bevy::{prelude::*, sprite::Mesh2dHandle};
+use bevy::prelude::*;
 
 use crate::engine::config::*;
-use crate::simulation::players::FacingDirection;
-
-use super::config::default_entity_size;
+use crate::simulation::players::{position_after_turn, FacingDirection};
 
 #[derive(Debug)]
 pub struct RungerError {
@@ -25,34 +23,6 @@ impl Display for RungerError {
 }
 
 impl Error for RungerError {}
-
-pub fn triangle_facing(
-    direction: &FacingDirection,
-    meshes: &mut ResMut<Assets<Mesh>>,
-) -> Mesh2dHandle {
-    match *direction {
-        FacingDirection::Up => Mesh2dHandle(meshes.add(Triangle2d::new(
-            Vec2::new(0., default_entity_size() / 2.),
-            Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
-            Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
-        ))),
-        FacingDirection::Right => Mesh2dHandle(meshes.add(Triangle2d::new(
-            Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
-            Vec2::new(default_entity_size() / 2., 0.),
-            Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
-        ))),
-        FacingDirection::Down => Mesh2dHandle(meshes.add(Triangle2d::new(
-            Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
-            Vec2::new(default_entity_size() / 2., default_entity_size() / 2.),
-            Vec2::new(0., -default_entity_size() / 2.),
-        ))),
-        FacingDirection::Left => Mesh2dHandle(meshes.add(Triangle2d::new(
-            Vec2::new(-default_entity_size() / 2., 0.),
-            Vec2::new(default_entity_size() / 2., default_entity_size() / 2.),
-            Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
-        ))),
-    }
-}
 
 #[derive(Component, Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub struct BoardPosition {
@@ -83,6 +53,16 @@ pub struct BoardState {
 
 #[derive(Component, Debug, Copy, Clone)]
 pub struct BoardTile;
+
+pub fn turn_right(is_facing: &mut FacingDirection, transform: &mut Transform) {
+    *is_facing = position_after_turn(is_facing, FacingDirection::Right).unwrap();
+    transform.rotate_z(-PI / 2.);
+}
+
+pub fn turn_left(is_facing: &mut FacingDirection, transform: &mut Transform) {
+    *is_facing = position_after_turn(is_facing, FacingDirection::Left).unwrap();
+    transform.rotate_z(PI / 2.);
+}
 
 pub fn predict_move_pos(player_pos: &BoardPosition, is_facing: &FacingDirection) -> (i32, i32) {
     match (&player_pos, is_facing) {

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -1,0 +1,54 @@
+use std::{error::Error, fmt::Display};
+
+use bevy::{prelude::*, sprite::Mesh2dHandle};
+
+use crate::simulation::players::FacingDirection;
+
+use super::config::default_entity_size;
+
+#[derive(Debug)]
+pub struct RungerError {
+    message: String,
+}
+
+pub fn rerror(msg: &'static str) -> Box<dyn Error> {
+    Box::new(RungerError {
+        message: msg.to_string(),
+    })
+}
+
+impl Display for RungerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for RungerError {}
+
+pub fn triangle_facing(
+    direction: &FacingDirection,
+    meshes: &mut ResMut<Assets<Mesh>>,
+) -> Mesh2dHandle {
+    match *direction {
+        FacingDirection::Up => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(0., default_entity_size() / 2.),
+            Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
+        ))),
+        FacingDirection::Right => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., 0.),
+            Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
+        ))),
+        FacingDirection::Down => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(0., -default_entity_size() / 2.),
+        ))),
+        FacingDirection::Left => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(-default_entity_size() / 2., 0.),
+            Vec2::new(default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
+        ))),
+    }
+}

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -16,3 +16,5 @@ pub fn default_tile_margin() -> f32 {
 pub fn default_player_count() -> u32 {
     ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
 }
+// TODO: config should include a constant that determines the amount of turns a single generation takes
+// TODO: should also include a constant that defines the speed (number of frames) of a single turn.

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -17,4 +17,4 @@ pub fn default_player_count() -> u32 {
     ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
 }
 pub const TURNS_PER_GEN: u32 = 300;
-pub const SECONDS_PER_TURN: f64 = 0.5;
+pub const SECONDS_PER_TURN: f64 = 0.1;

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -16,5 +16,5 @@ pub fn default_tile_margin() -> f32 {
 pub fn default_player_count() -> u32 {
     ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
 }
-// TODO: config should include a constant that determines the amount of turns a single generation takes
-// TODO: should also include a constant that defines the speed (number of frames) of a single turn.
+pub const TURNS_PER_GEN: u32 = 300;
+pub const SECONDS_PER_TURN: f64 = 0.5;

--- a/src/engine/debug.rs
+++ b/src/engine/debug.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+use crate::engine::common::BoardPosition;
+use crate::simulation::players::Player;
+
+use bevy::prelude::*;
+
+/// Debug system for logging if there are multiple players occupying the same tile
+fn log_positioning_conflicts(player_query: Query<&BoardPosition, With<Player>>) {
+    let mut conflict_map: HashMap<BoardPosition, u8> = HashMap::new();
+    for player_pos in player_query.iter() {
+        if !conflict_map.contains_key(player_pos) {
+            conflict_map.insert(*player_pos, 1);
+        } else {
+            let num_players = conflict_map.get(player_pos).unwrap() + 1;
+            conflict_map.insert(*player_pos, num_players);
+            error!(name: "kek", "Position {:#?} contains {} players!!", player_pos, num_players);
+        }
+    }
+}

--- a/src/engine/debug.rs
+++ b/src/engine/debug.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
-use crate::engine::common::BoardPosition;
-use crate::simulation::players::Player;
+use crate::engine::common::*;
+use crate::simulation::players::{Player, FacingDirection};
 
 use bevy::prelude::*;
+use bevy::sprite::Mesh2dHandle;
+
+use crate::engine::config::default_entity_size;
 
 /// Debug system for logging if there are multiple players occupying the same tile
 fn log_positioning_conflicts(player_query: Query<&BoardPosition, With<Player>>) {
@@ -15,5 +18,34 @@ fn log_positioning_conflicts(player_query: Query<&BoardPosition, With<Player>>) 
             conflict_map.insert(*player_pos, num_players);
             error!(name: "kek", "Position {:#?} contains {} players!!", player_pos, num_players);
         }
+    }
+}
+
+// A function for producing a triangle mesh facing one of four cardinal directions
+pub fn triangle_facing(
+    direction: &FacingDirection,
+    meshes: &mut ResMut<Assets<Mesh>>,
+) -> Mesh2dHandle {
+    match *direction {
+        FacingDirection::Up => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(0., default_entity_size() / 2.),
+            Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
+        ))),
+        FacingDirection::Right => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., 0.),
+            Vec2::new(-default_entity_size() / 2., -default_entity_size() / 2.),
+        ))),
+        FacingDirection::Down => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(-default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(0., -default_entity_size() / 2.),
+        ))),
+        FacingDirection::Left => Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::new(-default_entity_size() / 2., 0.),
+            Vec2::new(default_entity_size() / 2., default_entity_size() / 2.),
+            Vec2::new(default_entity_size() / 2., -default_entity_size() / 2.),
+        ))),
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub mod board;
+pub mod common;
 pub mod config;
 pub mod random;
 pub mod rsystem;

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -1,6 +1,9 @@
 use rand::{thread_rng, Rng};
 
-use crate::engine::config::*;
+use crate::{
+    engine::config::*,
+    simulation::players::{FacingDirection, PlayerActionType},
+};
 
 pub fn random_board_pos() -> (u32, u32) {
     let mut rng = thread_rng();
@@ -9,4 +12,17 @@ pub fn random_board_pos() -> (u32, u32) {
         rng.gen_range(0..DEFAULT_GRID_SIZE),
         rng.gen_range(0..DEFAULT_GRID_SIZE),
     )
+}
+
+pub fn random_player_action() -> PlayerActionType {
+    let mut rng = thread_rng();
+
+    let action_num = rng.gen_range(0..4);
+    match action_num {
+        0 => PlayerActionType::Idle,
+        1 => PlayerActionType::Move,
+        2 => PlayerActionType::Turn(FacingDirection::Left),
+        3 => PlayerActionType::Turn(FacingDirection::Right),
+        _ => unreachable!("{} is not allowed in random_action_type()", action_num),
+    }
 }

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -1,4 +1,7 @@
 use bevy::prelude::*;
 
+// TODO: Introduce the concept of types of player action:
+// -- The player can choose from certain types of action (move or turn for now)
+// -- Each turn, the player decides (either randomly or based on its "brain") which action from the types of actions available to take
 #[derive(Component, Debug)]
 pub struct Player;

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 
 use std::error::Error;
 
-// TODO: Each turn, the player decides (either randomly or based on its "brain") which action from the types of actions available to take
 #[derive(Component, Debug)]
 pub struct Player;
 

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -1,7 +1,46 @@
+use crate::engine::common::*;
+
 use bevy::prelude::*;
 
-// TODO: Introduce the concept of types of player action:
-// -- The player can choose from certain types of action (move or turn for now)
-// -- Each turn, the player decides (either randomly or based on its "brain") which action from the types of actions available to take
+use std::error::Error;
+
+// TODO: Each turn, the player decides (either randomly or based on its "brain") which action from the types of actions available to take
 #[derive(Component, Debug)]
 pub struct Player;
+
+#[derive(Component, Debug)]
+pub enum FacingDirection {
+    Up,
+    Left,
+    Down,
+    Right,
+}
+
+#[derive(Component, Debug)]
+pub enum PlayerActionType {
+    Idle,
+    Move,
+    Turn(FacingDirection),
+}
+
+pub fn position_after_turn(
+    is: &FacingDirection,
+    turn_direction: FacingDirection,
+) -> Result<FacingDirection, Box<dyn Error>> {
+    match turn_direction {
+        FacingDirection::Up => Err(rerror("Player tried to turn 'up', which is impossible")),
+        FacingDirection::Down => Err(rerror("Player tried to turn 'down', which is impossible")),
+        FacingDirection::Left => match is {
+            FacingDirection::Up => Ok(FacingDirection::Left),
+            FacingDirection::Right => Ok(FacingDirection::Up),
+            FacingDirection::Down => Ok(FacingDirection::Right),
+            FacingDirection::Left => Ok(FacingDirection::Down),
+        },
+        FacingDirection::Right => match is {
+            FacingDirection::Up => Ok(FacingDirection::Right),
+            FacingDirection::Right => Ok(FacingDirection::Down),
+            FacingDirection::Down => Ok(FacingDirection::Left),
+            FacingDirection::Left => Ok(FacingDirection::Up),
+        },
+    }
+}


### PR DESCRIPTION
A lot of work has been done in this PR:

- Introduced the concept of player action: players can choose a random action to perform each turn now;
- Implemented player actions: move 1 tile forward (in the direction it's facing), turn left, turn right;
- Introduced turns themselves as well as length of a single generation of players, which is 300 turns for now;
- A lot of refactoring and cleanup for all the work performed.