### PR TITLE
[issue #8] Implemented the food/hunger/starvation system.

### DIFF
--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -233,7 +233,7 @@ fn simulation_ongoing(turn: Res<Turn>) -> bool {
     turn.num <= TURNS_PER_GEN
 }
 fn simulation_over_once(turn: Res<Turn>, its_joever: Res<GameOver>) -> bool {
-    turn.num > TURNS_PER_GEN && its_joever.0 == false
+    turn.num > TURNS_PER_GEN && !its_joever.0
 }
 
 fn player_eat(
@@ -345,7 +345,7 @@ fn log_survival_rate(player_query: Query<&Vitals, With<Player>>, mut its_joever:
             PlayerStatus::DedPepega => died += 1,
         }
     }
-    warn!("Simulation over! Survived: {} players, died: {} players. Survival rate: {:.2}%.", survived, died, (survived as f32 / (survived + died) as f32) as f32 * 100.);
+    warn!("Simulation over! Survived: {} players, died: {} players. Survival rate: {:.2}%.", survived, died, (survived as f32 / (survived + died) as f32) * 100.);
 }
 
 pub struct GameBoardPlugin;

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -17,6 +17,14 @@ pub struct BoardTileBundle {
 pub struct PlayerBundle {
     pub board_pos: BoardPosition,
     pub is_facing: FacingDirection,
+    pub hunger: Hunger,
+    pub sprite: MaterialMesh2dBundle<ColorMaterial>,
+}
+
+#[derive(Bundle)]
+pub struct FoodBundle {
+    pub board_pos: BoardPosition,
+    pub satiation_value: Hunger,
     pub sprite: MaterialMesh2dBundle<ColorMaterial>,
 }
 
@@ -106,13 +114,14 @@ fn spawn_players(
                             PlayerBundle {
                                 board_pos: random_pos,
                                 is_facing: FacingDirection::Right,
+                                hunger: Hunger::new(random_hunger_start()),
                                 sprite: MaterialMesh2dBundle {
                                     mesh: triangle,
                                     material: materials.add(Color::rgb(1.0, 0.0, 0.0)),
                                     transform: Transform::from_xyz(
                                         grid_to_world(random_pos.x),
                                         grid_to_world(random_pos.y),
-                                        0.1,
+                                        1.0,
                                     )
                                     .with_rotation(Quat::from_rotation_z(-PI / 2.0)),
                                     ..default()
@@ -120,6 +129,53 @@ fn spawn_players(
                             },
                             Player,
                         ))
+                        .id(),
+                );
+                break;
+            }
+        }
+    }
+}
+
+fn spawn_food(
+    mut commands: Commands,
+    mut tile_query: Query<&mut OccupantType, With<BoardTile>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    board_state: Res<BoardState>,
+) {
+    for _ in 0..default_food_count() {
+        loop {
+            let random_pos = BoardPosition::from_tuple(random_board_pos());
+            if let Some(tile_id) = board_state.tiles.get(&random_pos) {
+                {
+                    let occ = tile_query.get(*tile_id);
+                    if occ.is_err() || *occ.unwrap() != OccupantType::Empty {
+                        continue;
+                    }
+                }
+
+                let occupant = tile_query.get_mut(*tile_id);
+                let mesh = meshes.add(Circle {
+                    radius: default_entity_size() / 2.,
+                });
+                let mut occupant = occupant.unwrap();
+                *occupant = OccupantType::Food(
+                    commands
+                        .spawn(FoodBundle {
+                            satiation_value: Hunger::new(default_food_value()),
+                            board_pos: random_pos,
+                            sprite: MaterialMesh2dBundle {
+                                mesh: Mesh2dHandle(mesh),
+                                material: materials.add(Color::rgb(1., 0.5, 0.)),
+                                transform: Transform::from_xyz(
+                                    grid_to_world(random_pos.x),
+                                    grid_to_world(random_pos.y),
+                                    0.9,
+                                ),
+                                ..default()
+                            },
+                        })
                         .id(),
                 );
                 break;
@@ -176,11 +232,16 @@ fn advance_players(
     board_state: Res<BoardState>,
     mut tile_query: Query<&mut OccupantType, With<BoardTile>>,
     mut player_query: Query<
-        (&mut BoardPosition, &mut FacingDirection, &mut Transform),
+        (
+            &mut BoardPosition,
+            &mut FacingDirection,
+            &mut Transform,
+            &mut Hunger,
+        ),
         With<Player>,
     >,
 ) {
-    for (mut pos, mut direction, mut transform) in player_query.iter_mut() {
+    for (mut pos, mut direction, mut transform, mut hunger) in player_query.iter_mut() {
         match random_player_action() {
             PlayerActionType::Idle => (),
             PlayerActionType::Move => move_player(
@@ -195,6 +256,9 @@ fn advance_players(
             }
             PlayerActionType::Turn(FacingDirection::Left) => {
                 turn_left(&mut direction, &mut transform)
+            }
+            PlayerActionType::Eat => {
+                () //player_eat(&pos, &direction, &mut hunger);
             }
             act => unreachable!(
                 "Incorrect action type while trying to advance players: {:#?}",
@@ -213,7 +277,7 @@ impl Plugin for GameBoardPlugin {
         app.insert_resource(BoardState::new())
             .insert_resource(Time::<Fixed>::from_seconds(SECONDS_PER_TURN))
             .insert_resource(Turn::new())
-            .add_systems(Startup, (spawn_board, spawn_players).chain())
+            .add_systems(Startup, (spawn_board, spawn_players, spawn_food).chain())
             .add_systems(FixedUpdate, advance_players.run_if(simulation_ongoing));
     }
 }

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -17,14 +17,14 @@ pub struct BoardTileBundle {
 pub struct PlayerBundle {
     pub board_pos: BoardPosition,
     pub is_facing: FacingDirection,
-    pub hunger: Hunger,
+    pub vitals: Vitals,
     pub sprite: MaterialMesh2dBundle<ColorMaterial>,
 }
 
 #[derive(Bundle)]
 pub struct FoodBundle {
     pub board_pos: BoardPosition,
-    pub satiation_value: Hunger,
+    pub energy_value: Hunger,
     pub sprite: MaterialMesh2dBundle<ColorMaterial>,
 }
 
@@ -38,6 +38,9 @@ impl Turn {
         Self { num: 1 }
     }
 }
+
+#[derive(Resource)]
+struct GameOver(bool);
 
 impl BoardState {
     pub fn new() -> Self {
@@ -114,7 +117,7 @@ fn spawn_players(
                             PlayerBundle {
                                 board_pos: random_pos,
                                 is_facing: FacingDirection::Right,
-                                hunger: Hunger::new(random_hunger_start()),
+                                vitals: Vitals::new(random_hunger_start()),
                                 sprite: MaterialMesh2dBundle {
                                     mesh: triangle,
                                     material: materials.add(Color::rgb(1.0, 0.0, 0.0)),
@@ -164,7 +167,7 @@ fn spawn_food(
                     commands
                         .spawn((
                             FoodBundle {
-                                satiation_value: Hunger::new(default_food_value()),
+                                energy_value: Hunger::new(default_food_value()),
                                 board_pos: random_pos,
                                 sprite: MaterialMesh2dBundle {
                                     mesh: Mesh2dHandle(mesh),
@@ -229,32 +232,48 @@ fn move_player(
 fn simulation_ongoing(turn: Res<Turn>) -> bool {
     turn.num <= TURNS_PER_GEN
 }
+fn simulation_over_once(turn: Res<Turn>, its_joever: Res<GameOver>) -> bool {
+    turn.num > TURNS_PER_GEN && its_joever.0 == false
+}
 
 fn player_eat(
     commands: &mut Commands,
     pos: &BoardPosition,
     direction: &FacingDirection,
-    hunger: &mut Hunger,
+    vitals: &mut Vitals,
     board_state: &Res<BoardState>,
     tile_query: &mut Query<&mut OccupantType, With<BoardTile>>,
     food_query: &Query<&Hunger, (With<Food>, Without<Player>)>,
 ) {
     let food_pos = predict_move_pos(pos, direction);
+    if !pos_within_bounds(&food_pos) {
+        return;
+    }
+
     let food_tile_id = board_state
         .tiles
         .get(&BoardPosition::new(food_pos.0 as u32, food_pos.1 as u32))
         .copied();
     let occupant = tile_query.get_mut(food_tile_id.unwrap());
-    if !pos_within_bounds(&food_pos) || occupant.is_err() {
-        return;
-    }
 
     if let Ok(mut occ) = occupant {
         if let OccupantType::Food(food_id) = *occ {
-            hunger.value += food_query.get(food_id).unwrap().value;
+            vitals.hunger.value += food_query.get(food_id).unwrap().value;
             commands.entity(food_id).despawn_recursive();
             *occ = OccupantType::Empty;
         }
+    }
+}
+
+fn update_player_vitals(
+    vitals: &mut Vitals,
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+    player_mat: &mut Handle<ColorMaterial>,
+) {
+    vitals.hunger.value -= 1;
+    if vitals.hunger.value == 0 {
+        vitals.status = PlayerStatus::DedPepega;
+        *player_mat = materials.add(Color::rgb(0., 0., 0.));
     }
 }
 
@@ -262,19 +281,24 @@ fn advance_players(
     mut commands: Commands,
     mut turn: ResMut<Turn>,
     board_state: Res<BoardState>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
     mut tile_query: Query<&mut OccupantType, With<BoardTile>>,
     mut player_query: Query<
         (
             &mut BoardPosition,
             &mut FacingDirection,
             &mut Transform,
-            &mut Hunger,
+            &mut Vitals,
+            &mut Handle<ColorMaterial>,
         ),
         With<Player>,
     >,
     food_query: Query<&Hunger, (With<Food>, Without<Player>)>,
 ) {
-    for (mut pos, mut direction, mut transform, mut hunger) in player_query.iter_mut() {
+    for (mut pos, mut direction, mut transform, mut vitals, mut player_mat) in player_query.iter_mut() {
+        if vitals.status == PlayerStatus::DedPepega {
+            continue;
+        }
         match random_player_action() {
             PlayerActionType::Idle => (),
             PlayerActionType::Move => move_player(
@@ -295,7 +319,7 @@ fn advance_players(
                     &mut commands,
                     &pos,
                     &direction,
-                    &mut hunger,
+                    &mut vitals,
                     &board_state,
                     &mut tile_query,
                     &food_query,
@@ -306,10 +330,22 @@ fn advance_players(
                 act
             ),
         }
-        // update_player_vitals();
+        update_player_vitals(&mut vitals, &mut materials, &mut player_mat);
     }
 
     turn.num += 1;
+}
+
+fn log_survival_rate(player_query: Query<&Vitals, With<Player>>, mut its_joever: ResMut<GameOver>) {
+    its_joever.0 = true;
+    let (mut survived, mut died): (u32, u32) = (0, 0);
+    for vitals in player_query.iter() {
+        match vitals.status {
+            PlayerStatus::Alive => survived += 1,
+            PlayerStatus::DedPepega => died += 1,
+        }
+    }
+    warn!("Simulation over! Survived: {} players, died: {} players. Survival rate: {:.2}%.", survived, died, (survived as f32 / (survived + died) as f32) as f32 * 100.);
 }
 
 pub struct GameBoardPlugin;
@@ -319,7 +355,10 @@ impl Plugin for GameBoardPlugin {
         app.insert_resource(BoardState::new())
             .insert_resource(Time::<Fixed>::from_seconds(SECONDS_PER_TURN))
             .insert_resource(Turn::new())
+            .insert_resource(GameOver(false))
             .add_systems(Startup, (spawn_board, spawn_players, spawn_food).chain())
-            .add_systems(FixedUpdate, advance_players.run_if(simulation_ongoing));
+            .add_systems(FixedUpdate, advance_players.run_if(simulation_ongoing))
+            .add_systems(FixedLast, log_survival_rate.run_if(simulation_over_once));
+
     }
 }

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -44,6 +44,7 @@ impl BoardPosition {
 pub enum OccupantType {
     Empty,
     Player(Entity),
+    Food(Entity),
 }
 
 #[derive(Resource)]

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -74,14 +74,18 @@ pub fn predict_move_pos(player_pos: &BoardPosition, is_facing: &FacingDirection)
     }
 }
 
+pub fn pos_within_bounds(pos_to_check: &(i32, i32)) -> bool {
+    pos_to_check.0 >= 0
+        && pos_to_check.1 >= 0
+        && pos_to_check.0 < DEFAULT_GRID_SIZE as i32
+        && pos_to_check.1 < DEFAULT_GRID_SIZE as i32
+}
+
 pub fn tile_entity_by_pos<'a>(
     new_pos: (i32, i32),
     board_state: &'a Res<BoardState>,
 ) -> Option<&'a Entity> {
-    let within_bounds = new_pos.0 >= 0
-        && new_pos.1 >= 0
-        && new_pos.0 < DEFAULT_GRID_SIZE as i32
-        && new_pos.1 < DEFAULT_GRID_SIZE as i32;
+    let within_bounds = pos_within_bounds(&new_pos);
     if within_bounds {
         board_state
             .tiles

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -14,7 +14,19 @@ pub fn default_tile_margin() -> f32 {
     DEFAULT_TILE_SIZE * percent(15)
 }
 pub fn default_player_count() -> u32 {
-    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
+    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(30)) as u32
 }
 pub const TURNS_PER_GEN: u32 = 300;
+pub fn default_food_count() -> u32 {
+    (default_player_count() as f32 * percent(50)) as u32
+}
+pub fn default_hunger_min() -> u32 {
+    TURNS_PER_GEN / 2
+}
+pub fn default_hunger_max() -> u32 {
+    (TURNS_PER_GEN as f32 / 1.5) as u32
+}
+pub fn default_food_value() -> u32 {
+    TURNS_PER_GEN / 3 * 2
+}
 pub const SECONDS_PER_TURN: f64 = 0.1;

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -14,7 +14,7 @@ pub fn default_tile_margin() -> f32 {
     DEFAULT_TILE_SIZE * percent(15)
 }
 pub fn default_player_count() -> u32 {
-    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(30)) as u32
+    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(50)) as u32
 }
 pub const TURNS_PER_GEN: u32 = 300;
 pub fn default_food_count() -> u32 {

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -14,7 +14,7 @@ pub fn default_tile_margin() -> f32 {
     DEFAULT_TILE_SIZE * percent(15)
 }
 pub fn default_player_count() -> u32 {
-    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(50)) as u32
+    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
 }
 pub const TURNS_PER_GEN: u32 = 300;
 pub fn default_food_count() -> u32 {

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -17,12 +17,18 @@ pub fn random_board_pos() -> (u32, u32) {
 pub fn random_player_action() -> PlayerActionType {
     let mut rng = thread_rng();
 
-    let action_num = rng.gen_range(0..4);
+    let action_num = rng.gen_range(0..5);
     match action_num {
         0 => PlayerActionType::Idle,
         1 => PlayerActionType::Move,
         2 => PlayerActionType::Turn(FacingDirection::Left),
         3 => PlayerActionType::Turn(FacingDirection::Right),
+        4 => PlayerActionType::Eat,
         _ => unreachable!("{} is not allowed in random_action_type()", action_num),
     }
+}
+
+pub fn random_hunger_start() -> u32 {
+    let mut rng = thread_rng();
+    rng.gen_range(default_hunger_min()..=default_hunger_max())
 }

--- a/src/engine/rsystem.rs
+++ b/src/engine/rsystem.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy::window::WindowResolution;
+use bevy::window::{PresentMode, WindowResolution};
 
 fn camera_setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
@@ -15,6 +15,7 @@ impl Plugin for BaseSystemPlugin {
                 primary_window: Some(Window {
                     title: "Runger: The Hunger Games simulation".to_string(),
                     resolution: WindowResolution::new(1280., 720.).with_scale_factor_override(1.0),
+                    present_mode: PresentMode::Fifo,
                     ..default()
                 }),
                 ..default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#[allow(clippy::type_complexity)]
+
 mod engine;
 mod simulation;
 

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -8,6 +8,9 @@ use std::error::Error;
 pub struct Player;
 
 #[derive(Component, Debug)]
+pub struct Food;
+
+#[derive(Component, Debug)]
 pub enum FacingDirection {
     Up,
     Left,
@@ -20,6 +23,18 @@ pub enum PlayerActionType {
     Idle,
     Move,
     Turn(FacingDirection),
+    Eat,
+}
+
+#[derive(Component, Debug)]
+pub struct Hunger {
+    pub value: u32,
+}
+
+impl Hunger {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
 }
 
 pub fn position_after_turn(

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -26,14 +26,32 @@ pub enum PlayerActionType {
     Eat,
 }
 
+#[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PlayerStatus {
+    Alive,
+    DedPepega,
+}
+
 #[derive(Component, Debug)]
 pub struct Hunger {
-    pub value: u32,
+    pub value: u32
 }
 
 impl Hunger {
     pub fn new(value: u32) -> Self {
         Self { value }
+    }
+}
+
+#[derive(Component, Debug)]
+pub struct Vitals {
+    pub hunger: Hunger,
+    pub status: PlayerStatus,
+}
+
+impl Vitals {
+    pub fn new(hunger: u32) -> Self {
+        Self { hunger: Hunger::new(hunger), status: PlayerStatus::Alive }
     }
 }
 


### PR DESCRIPTION
- Now spawning some food at the start of each simulation;
- Players get hungry as the simulation progresses now;
- Players can eat food and restore some of their hunger;
- If a player doesn't get any food before its hunger reaches 0, it dies.