### PR TITLE
[issue #22] Refactored advance_players() into events with parallel handling for each action type

### DIFF
--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, error::Error, f32::consts::PI, fmt::Display};
+use std::{collections::HashMap, error::Error, fmt::Display};
 
 use bevy::prelude::*;
 
 use crate::engine::config::*;
-use crate::simulation::players::{position_after_turn, FacingDirection};
+use crate::simulation::players::FacingDirection;
 
 #[derive(Debug)]
 pub struct RungerError {
@@ -55,22 +55,18 @@ pub struct BoardState {
 #[derive(Component, Debug, Copy, Clone)]
 pub struct BoardTile;
 
-pub fn turn_right(is_facing: &mut FacingDirection, transform: &mut Transform) {
-    *is_facing = position_after_turn(is_facing, FacingDirection::Right).unwrap();
-    transform.rotate_z(-PI / 2.);
-}
-
-pub fn turn_left(is_facing: &mut FacingDirection, transform: &mut Transform) {
-    *is_facing = position_after_turn(is_facing, FacingDirection::Left).unwrap();
-    transform.rotate_z(PI / 2.);
+#[derive(Debug)]
+pub enum FoodType {
+    Meal,
+    DeadMeat,
 }
 
 pub fn predict_move_pos(player_pos: &BoardPosition, is_facing: &FacingDirection) -> (i32, i32) {
     match (&player_pos, is_facing) {
-        (BoardPosition { x, y }, FacingDirection::Up) => (*x as i32, (*y + 1) as i32),
-        (BoardPosition { x, y }, FacingDirection::Right) => ((*x + 1) as i32, *y as i32),
-        (BoardPosition { x, y }, FacingDirection::Down) => (*x as i32, (*y - 1) as i32),
-        (BoardPosition { x, y }, FacingDirection::Left) => ((*x - 1) as i32, *y as i32),
+        (BoardPosition { x, y }, FacingDirection::Up) => (*x as i32, (*y as i32 + 1)),
+        (BoardPosition { x, y }, FacingDirection::Right) => ((*x as i32 + 1), *y as i32),
+        (BoardPosition { x, y }, FacingDirection::Down) => (*x as i32, (*y as i32 - 1)),
+        (BoardPosition { x, y }, FacingDirection::Left) => ((*x as i32 - 1), *y as i32),
     }
 }
 

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -29,4 +29,7 @@ pub fn default_hunger_max() -> u32 {
 pub fn default_food_value() -> u32 {
     TURNS_PER_GEN / 3 * 2
 }
+pub fn default_player_food_value() -> u32 {
+    default_food_value() / 2
+}
 pub const SECONDS_PER_TURN: f64 = 0.1;

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -14,7 +14,7 @@ pub fn default_tile_margin() -> f32 {
     DEFAULT_TILE_SIZE * percent(15)
 }
 pub fn default_player_count() -> u32 {
-    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(50)) as u32
+    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(65)) as u32
 }
 pub const TURNS_PER_GEN: u32 = 300;
 pub fn default_food_count() -> u32 {

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -14,7 +14,7 @@ pub fn default_tile_margin() -> f32 {
     DEFAULT_TILE_SIZE * percent(15)
 }
 pub fn default_player_count() -> u32 {
-    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(10)) as u32
+    ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(50)) as u32
 }
 pub const TURNS_PER_GEN: u32 = 300;
 pub fn default_food_count() -> u32 {

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -17,13 +17,14 @@ pub fn random_board_pos() -> (u32, u32) {
 pub fn random_player_action() -> PlayerActionType {
     let mut rng = thread_rng();
 
-    let action_num = rng.gen_range(0..5);
+    let action_num = rng.gen_range(0..6);
     match action_num {
         0 => PlayerActionType::Idle,
         1 => PlayerActionType::Move,
         2 => PlayerActionType::Turn(FacingDirection::Left),
         3 => PlayerActionType::Turn(FacingDirection::Right),
         4 => PlayerActionType::Eat,
+        5 => PlayerActionType::Kill,
         _ => unreachable!("{} is not allowed in random_action_type()", action_num),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #[allow(clippy::type_complexity)]
-
 mod engine;
 mod simulation;
 

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -24,6 +24,7 @@ pub enum PlayerActionType {
     Move,
     Turn(FacingDirection),
     Eat,
+    Kill,
 }
 
 #[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]
@@ -34,7 +35,7 @@ pub enum PlayerStatus {
 
 #[derive(Component, Debug)]
 pub struct Hunger {
-    pub value: u32
+    pub value: u32,
 }
 
 impl Hunger {
@@ -51,7 +52,10 @@ pub struct Vitals {
 
 impl Vitals {
     pub fn new(hunger: u32) -> Self {
-        Self { hunger: Hunger::new(hunger), status: PlayerStatus::Alive }
+        Self {
+            hunger: Hunger::new(hunger),
+            status: PlayerStatus::Alive,
+        }
     }
 }
 

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -10,7 +10,7 @@ pub struct Player;
 #[derive(Component, Debug)]
 pub struct Food;
 
-#[derive(Component, Debug)]
+#[derive(Component, Debug, Clone, Copy)]
 pub enum FacingDirection {
     Up,
     Left,


### PR DESCRIPTION
#7 encountered an issue with player_query where it tried to borrow player_query mutably from the top-level advance_players, but the query had been already borrowed by the loop in advance_players itself at this point.

Plus, the signature of advance_players had grown to the point of being absolutely massive due to handling everything on its own.

This is a rework of the player action system into events where each action has its own listener, which is its own parallel system and can therefore request necessary components and resources from Bevy on its own, taking the load off of advance_players.

NOTE: the only downside is that due to each action handler becoming a separate parallel system, there can be conflicts sometimes. And while some of them are fine (like one player deciding to eat food and a different player snatching the food before the first one, or two players killing each other within one turn), some (like player ending up on the same tile with food) are annoying. Therefore, maybe in the future once the pros and cons of this architecture become a bit more clear, we could maybe think about refactoring into something for the third time OR maybe we could think of some way of fixing these concurrency issues.