### PR TITLE
[issue #29] Implemented action cost + renamed all Hunger to Energy.

### DIFF
--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -17,6 +17,7 @@ pub struct BoardTileBundle {
 pub struct PlayerBundle {
     pub board_pos: BoardPosition,
     pub is_facing: FacingDirection,
+    pub last_action_taken: PlayerActionType,
     pub vitals: Vitals,
     pub sprite: MaterialMesh2dBundle<ColorMaterial>,
 }
@@ -86,7 +87,8 @@ fn spawn_players(
                             PlayerBundle {
                                 board_pos: random_pos,
                                 is_facing: FacingDirection::Right,
-                                vitals: Vitals::new(random_hunger_start()),
+                                last_action_taken: PlayerActionType::Idle,
+                                vitals: Vitals::new(random_energy_start()),
                                 sprite: MaterialMesh2dBundle {
                                     mesh: triangle,
                                     material: materials.add(Color::rgb(1.0, 0.0, 0.0)),
@@ -148,17 +150,19 @@ fn advance_turn(mut turn: ResMut<Turn>, mut states: ResMut<NextState<VisualizerS
 
 fn log_survival_rate(player_query: Query<&Vitals, With<Player>>) {
     let mut survived: u32 = 0;
+    let mut not_killed: u32 = 0;
     for vitals in player_query.iter() {
         match vitals.status {
             PlayerStatus::Alive => survived += 1,
-            PlayerStatus::DedPepega => (),
+            PlayerStatus::DedPepega => not_killed += 1,
         }
     }
     warn!(
-        "Simulation over! Started with {} players. Survived: {} players, died: {} players. Survival rate: {:.2}%.",
+        "Simulation over! Started with {} players. Survived: {} players, murdered: {} players, died from hunger: {} players. Survival rate: {:.2}%.",
         default_player_count(),
         survived,
-        default_player_count() - survived,
+        default_player_count() - survived - not_killed,
+        not_killed,
         (survived as f32 / default_player_count() as f32) * 100.
     );
 }

--- a/src/engine/common.rs
+++ b/src/engine/common.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
 
 use crate::engine::config::*;
-use crate::simulation::players::{FacingDirection, Food, Hunger};
+use crate::simulation::players::{FacingDirection, Food, Energy};
 
 #[derive(Debug)]
 pub struct RungerError {
@@ -129,7 +129,7 @@ pub enum FoodType {
 #[derive(Bundle)]
 pub struct FoodBundle {
     pub board_pos: BoardPosition,
-    pub energy_value: Hunger,
+    pub energy_value: Energy,
     pub sprite: MaterialMesh2dBundle<ColorMaterial>,
 }
 
@@ -170,7 +170,7 @@ pub fn place_food_at(
             commands
                 .spawn((
                     FoodBundle {
-                        energy_value: Hunger::new(energy_value),
+                        energy_value: Energy::new(energy_value),
                         board_pos: pos,
                         sprite: MaterialMesh2dBundle {
                             mesh: Mesh2dHandle(mesh),

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -1,6 +1,12 @@
+use crate::simulation::players::*;
+
+// UTILITIES
+
 pub fn percent(value: u8) -> f32 {
     value as f32 * 0.01
 }
+
+// BOARD
 
 pub const DEFAULT_GRID_SIZE: u32 = 16;
 pub const DEFAULT_TILE_SIZE: f32 = 38.0;
@@ -16,20 +22,37 @@ pub fn default_tile_margin() -> f32 {
 pub fn default_player_count() -> u32 {
     ((DEFAULT_GRID_SIZE * DEFAULT_GRID_SIZE) as f32 * percent(66)) as u32
 }
+
+// SIMULATION
+
 pub const TURNS_PER_GEN: u32 = 300;
+pub const SECONDS_PER_TURN: f64 = 0.1;
+
+// FOOD
 pub fn default_food_count() -> u32 {
     (default_player_count() as f32 * percent(50)) as u32
 }
-pub fn default_hunger_min() -> u32 {
+pub fn default_energy_min() -> u32 {
     TURNS_PER_GEN / 2
 }
-pub fn default_hunger_max() -> u32 {
+pub fn default_energy_max() -> u32 {
     (TURNS_PER_GEN as f32 / 1.5) as u32
 }
 pub fn default_food_value() -> u32 {
     TURNS_PER_GEN / 3 * 2
 }
 pub fn default_player_food_value() -> u32 {
-    default_food_value() / 2
+    default_food_value() / 2 + 1
 }
-pub const SECONDS_PER_TURN: f64 = 0.1;
+
+// ACTIONS
+
+pub fn action_cost(action_type: &PlayerActionType) -> u32 {
+    match *action_type {
+        PlayerActionType::Idle => 1,
+        PlayerActionType::Turn(_) => 1,
+        PlayerActionType::Eat => 2,
+        PlayerActionType::Move => 3,
+        PlayerActionType::Kill => 50,
+    }
+}

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -29,7 +29,7 @@ pub fn random_player_action() -> PlayerActionType {
     }
 }
 
-pub fn random_hunger_start() -> u32 {
+pub fn random_energy_start() -> u32 {
     let mut rng = thread_rng();
-    rng.gen_range(default_hunger_min()..=default_hunger_max())
+    rng.gen_range(default_energy_min()..=default_energy_max())
 }

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -34,11 +34,11 @@ pub enum PlayerStatus {
 }
 
 #[derive(Component, Debug)]
-pub struct Hunger {
+pub struct Energy {
     pub value: u32,
 }
 
-impl Hunger {
+impl Energy {
     pub fn new(value: u32) -> Self {
         Self { value }
     }
@@ -46,14 +46,14 @@ impl Hunger {
 
 #[derive(Component, Debug)]
 pub struct Vitals {
-    pub hunger: Hunger,
+    pub energy: Energy,
     pub status: PlayerStatus,
 }
 
 impl Vitals {
-    pub fn new(hunger: u32) -> Self {
+    pub fn new(energy_value: u32) -> Self {
         Self {
-            hunger: Hunger::new(hunger),
+            energy: Energy::new(energy_value),
             status: PlayerStatus::Alive,
         }
     }


### PR DESCRIPTION
- Implemented action cost and adjusted reasonable costs for each action type;
- All Hunger is now Energy (Hunger is supposed to be going up, but it was ticking down, so it functions more like energy reserves for the player);

NOTE: In many cases, action cost comes at the price of making an additional Bevy query for the last action taken to analyze it (and each player action now has to not forget to update last action taken in its own listener). This strikes me as not ideal in terms of code quality. Hopefully I can think of a less annoying method of tracking the energy cost for last action taken in the future.