### PR TITLE
[issue #31] Implemented the disengage action as a move variant (move 3 empty tiles backwards)

### DIFF
--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -56,9 +56,12 @@ pub fn action_cost(action_type: &PlayerActionType) -> u32 {
         PlayerActionType::ScanLOS => 1,
         PlayerActionType::Eat => 2,
         PlayerActionType::Move => 3,
+        PlayerActionType::Disengage => 15,
         PlayerActionType::Kill => 50,
     }
 }
+
+pub const DISENGAGE_LENGTH: u32 = 3;
 
 // LINE OF SIGHT MECHANICS
 

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -17,7 +17,7 @@ pub fn random_board_pos() -> (u32, u32) {
 pub fn random_player_action() -> PlayerActionType {
     let mut rng = thread_rng();
 
-    let action_num = rng.gen_range(0..7);
+    let action_num = rng.gen_range(0..8);
     match action_num {
         0 => PlayerActionType::Idle,
         1 => PlayerActionType::Move,
@@ -26,6 +26,7 @@ pub fn random_player_action() -> PlayerActionType {
         4 => PlayerActionType::Eat,
         5 => PlayerActionType::Kill,
         6 => PlayerActionType::ScanLOS,
+        7 => PlayerActionType::Disengage,
         _ => unreachable!("{} is not allowed in random_action_type()", action_num),
     }
 }

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -26,6 +26,7 @@ pub enum PlayerActionType {
     Eat,
     Kill,
     ScanLOS,
+    Disengage,
 }
 
 #[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -10,7 +10,7 @@ pub struct Player;
 #[derive(Component, Debug)]
 pub struct Food;
 
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FacingDirection {
     Up,
     Left,


### PR DESCRIPTION
NOTE: there is a minor bug because of a conflict with color blinking on line of sight detection where if a player dies in the same turn as it changes color due to line of sight, it will return to its old "alive" red color instead of the correct black to indicate that it's dead. This is not a big issue because in the future color blinking is going to be replaced with using line of sight detection properly, so the issue is temporary and therefore is not worth fixing.