### PR TITLE
[issue #41] Remove disengage, rename actions to Move Forward and Backwards

### DIFF
--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -56,8 +56,8 @@ pub fn action_cost(action_type: &PlayerActionType) -> u32 {
         PlayerActionType::Turn(_) => 1,
         PlayerActionType::ScanLOS => 1,
         PlayerActionType::Eat => 2,
-        PlayerActionType::Move => 3,
-        PlayerActionType::Disengage => DISENGAGE_LENGTH * 7,
+        PlayerActionType::MoveForward => 3,
+        PlayerActionType::MoveBackwards => 3,
         PlayerActionType::Kill => 40,
     }
 }

--- a/src/engine/random.rs
+++ b/src/engine/random.rs
@@ -17,16 +17,15 @@ pub fn random_board_pos() -> (u32, u32) {
 pub fn random_player_action() -> PlayerActionType {
     let mut rng = thread_rng();
 
-    let action_num = rng.gen_range(0..8);
+    let action_num = rng.gen_range(0..7);
     match action_num {
         0 => PlayerActionType::Idle,
-        1 => PlayerActionType::Move,
+        1 => PlayerActionType::MoveForward,
         2 => PlayerActionType::Turn(FacingDirection::Left),
         3 => PlayerActionType::Turn(FacingDirection::Right),
         4 => PlayerActionType::Eat,
         5 => PlayerActionType::Kill,
         6 => PlayerActionType::ScanLOS,
-        7 => PlayerActionType::Disengage,
         _ => unreachable!("{} is not allowed in random_action_type()", action_num),
     }
 }

--- a/src/simulation/players.rs
+++ b/src/simulation/players.rs
@@ -21,12 +21,13 @@ pub enum FacingDirection {
 #[derive(Component, Debug)]
 pub enum PlayerActionType {
     Idle,
-    Move,
+    MoveForward,
+    #[allow(dead_code)]
+    MoveBackwards,
     Turn(FacingDirection),
     Eat,
     Kill,
     ScanLOS,
-    Disengage,
 }
 
 #[derive(Component, Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
- Removed the disengage action from the code as it was lacking the concepts of time and speed, and was therefore buggy;
- Renamed "move" to "move forwards"
- The unused code for Disengage is not called "move backwards"
- The task for properly letting the players move forward or backwards (standard 1 tile move) has already been created: it's #46.